### PR TITLE
Update FlowerStormPaaS.csv

### DIFF
--- a/FlowerStormPaaS.csv
+++ b/FlowerStormPaaS.csv
@@ -1587,3 +1587,4 @@ ip,43.133.184.179,IP of the resolved malicious domain at the time of activity an
 ip,69.49.230.198,IP of the resolved malicious domain at the time of activity and observed in EntraID sign-in logs. 
 ip,162.241.71.126,IP of the resolved malicious domain at the time of activity and observed in EntraID sign-in logs. 
 email,leonidbo4kariev[@]gmail[.]com,Email address utilized to register newer phising domains. 
+domain,malccewqaw.website,FlowerStorm phishing domain


### PR DESCRIPTION
New C2 server has been discovered in a phishing campaign targeting an organization in Egypt.
The C2 server is undetected over virustotal and other cti platforms.
The phishing website used microlink service to capture a screenshot from the background of a legitmate website.
The phishing website used debugging/obfuscation techniques to complicate the analysis.
The phishing website used a custom javascript file to display the page based on the user language.
The phishing website related to FlowerStorm phishing as a service platform.
Related indicators:
- hxxp://uq1xslfi7a[.]pages[.]dev/bqxrfiyo?ndbgrrclvp=